### PR TITLE
Use UrlHandle when Sitecore 7.5 is present.

### DIFF
--- a/App_Config/Includes/Monoco.CMS.FieldTypes.config
+++ b/App_Config/Includes/Monoco.CMS.FieldTypes.config
@@ -15,6 +15,7 @@
 
     <settings>
       <setting name="Monoco.CMS.Linklist.SitecoreVersionIsPre7.2" value="true" />
+      <setting name="Monoco.CMS.Linklist.SitecoreVersionIsPre7.5" value="true" />
     </settings>
     
   </sitecore>

--- a/sitecore modules/Shell/FieldTypes/LinkListField.cs
+++ b/sitecore modules/Shell/FieldTypes/LinkListField.cs
@@ -113,7 +113,8 @@ namespace Monoco.CMS.FieldTypes
                 // Sitecore 7.2 uses urlHandle to transfer the va variable, 
                 // so if we're 7.2 or above, use UrlHandle, otherwise, use urlString
                 var isPre72Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.2", false);
-                if (isPre72Version || args.Parameters["url"] == InternalLinkDialogUrl)
+                var isPre75Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.5", false);
+                if (isPre72Version || (isPre75Version && args.Parameters["url"] == InternalLinkDialogUrl))
                 {
                     urlString.Append("va", node.OuterXml);
                 }
@@ -180,7 +181,8 @@ namespace Monoco.CMS.FieldTypes
                 // Sitecore 7.2 uses urlHandle to transfer the va variable, 
                 // so if we're 7.2 or above, use UrlHandle, otherwise, use urlString
                 var isPre72Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.2", false);
-                if (isPre72Version || args.Parameters["url"] == InternalLinkDialogUrl)
+                var isPre75Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.5", false);
+                if (isPre72Version || (isPre75Version && args.Parameters["url"] == InternalLinkDialogUrl))
                 {
                     urlString.Append("va", XmlValue.ToString());
                 }


### PR DESCRIPTION
In Sitecore 7.5, the Internal Link dialog doesn't open to the selected
node unless the value of va is sent via UrlHandle. Introducing a
configuration setting to specify that Sitecore 7.5 is present, and
UrlHandle can be used when editing or inserting internal links.
